### PR TITLE
Fixed bug where setMuteState() was passing raw channel number instead of enum value

### DIFF
--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -204,7 +204,7 @@ export default class Client extends EventEmitter {
     this.sendPacket(
       MessageTypes.Setting,
       Buffer.concat([
-        Buffer.from(`${channel}/${ACTIONS.MUTE}\x00\x00\x00`),
+        Buffer.from(`${CHANNELS['CHANNEL_' + channel]}/${ACTIONS.MUTE}\x00\x00\x00`),
         onOffCode(state)
       ])
     )


### PR DESCRIPTION
Fixes https://github.com/featherbear/presonus-studiolive-api/issues/3