### PR TITLE
Add connection loss error hook

### DIFF
--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -173,6 +173,10 @@ export class Client extends EventEmitter {
         return reject(err)
       }
 
+      //remove possibly added listeners, so events are not fired multiple times
+      this.conn.removeAllListeners("error");
+      this.conn.removeAllListeners("close");
+
       this.conn.once('error', rejectHandler(ConnectionState.Error))
       this.conn.once('close', rejectHandler(ConnectionState.Closed))
 

--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -245,9 +245,11 @@ export class Client extends EventEmitter {
           if (this.conn.destroyed || (now - lastKeepAlive > 1500)) {
             clearInterval(keepAliveLoop)
             if(!this.conn.destroyed) {
+              // if the socket is still alive and the connection is closed 
+              // because the keepalive packets have not been send in the last 1,5 seconds
+              // the connection is closed here
               this.conn.destroy()
             }
-            this.emit(ConnectionState.Closed)
             return
           }
           lastKeepAlive = now

--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -244,6 +244,9 @@ export class Client extends EventEmitter {
           const now = new Date().getTime();
           if (this.conn.destroyed || (now - lastKeepAlive > 1500)) {
             clearInterval(keepAliveLoop)
+            if(!this.conn.destroyed) {
+              this.conn.destroy()
+            }
             this.emit(ConnectionState.Closed)
             return
           }

--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -239,11 +239,15 @@ export class Client extends EventEmitter {
 
         // #region Keep alive
         // Send a KeepAlive packet every second
+        let lastKeepAlive = new Date().getTime();
         const keepAliveLoop = setInterval(() => {
-          if (this.conn.destroyed) {
+          const now = new Date().getTime();
+          if (this.conn.destroyed || (now - lastKeepAlive > 1500)) {
             clearInterval(keepAliveLoop)
+            this.emit(ConnectionState.Closed)
             return
           }
+          lastKeepAlive = now
           this._sendPacket(MessageCode.KeepAlive)
         }, 1000)
         // #endregion

--- a/src/lib/constants/connection.ts
+++ b/src/lib/constants/connection.ts
@@ -1,0 +1,4 @@
+export enum ConnectionState {
+    Error = "error",
+    Closed = "closed"
+}


### PR DESCRIPTION
Hi,
this is my first attempt on creating an error hook for connection losses or other connection errors like timeouts.

Usage would be:
```
const client = new Client('192.168.178.57');

client.on(ConnectionState.Closed, () => {
  console.log("closed")
})

client.on(ConnectionState.Error, (e) => {
  console.log("error", e)
})

client.connect().then(() => {
    // do something
  }).catch(()=> {
    // catch initial connection error, produced by promise rejection
  })
}
```

If the catch statement after the connect method, even if on(error) is hooked, the application crashes, because  of a promise rejection error.If the error occurs before the first connection is possible, the catch code is executed as well.
But regardless of when the error occurs, the error function is always called, I tried it on a StudioLive 32R mixer, there it works perfectly.
The close method is called every time the connection to the mixer is closed, so if successfully closed, or closed by a network error.

If you have any comments on that, please let me know. I am thinking if there is anything to improve with the solution I implemented, thats why the pull request is still a draft :)